### PR TITLE
Python script to invoke watson STT

### DIFF
--- a/scripts/credentials.json.sample
+++ b/scripts/credentials.json.sample
@@ -1,0 +1,8 @@
+{
+  "apikey": "apikey",
+  "iam_apikey_description": "Auto generated apikey during resource-key operation for Instance - ",
+  "iam_apikey_name": "auto-generated-apikey",
+  "iam_role_crn": "crn:v1:bluemix:public:iam::::serviceRole:User",
+  "iam_serviceid_crn": "",
+  "url": "https://stream.watsonplatform.net/speech-to-text/api"
+}

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+ibm-watson

--- a/scripts/words-probabilities.py
+++ b/scripts/words-probabilities.py
@@ -1,0 +1,43 @@
+from ibm_watson import SpeechToTextV1
+from os.path import join, dirname
+import json
+import argparse
+
+
+def getKey(loc):
+    with open(loc) as json_file:
+        data = json.load(json_file)
+    return dict(apikey=data['apikey'], url=data['url'])
+
+
+def speech_to_text(audio, key, url):
+    speech_to_text = SpeechToTextV1(iam_apikey=key ,url=url)
+
+    with open(join(dirname(__file__), audio),'rb') as audio_file:
+        results = speech_to_text.recognize(
+            audio=audio_file,
+            content_type='audio/wav',
+            word_alternatives_threshold=0.9
+        ).get_result()
+    
+    words_probabilities = []
+    for result in results['results']:
+        for alternative in result['word_alternatives']:
+            one_word = []
+            for word in alternative['alternatives']:
+                one_word.append((word['word'], word['confidence']))
+            
+            words_probabilities.append(one_word)
+
+    return words_probabilities
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Watson Speech to Text')
+    parser.add_argument('credentials', type=str,
+                      help='credential json file for Watson speech to text service')
+    parser.add_argument('audio', type=str, help='audio file to transcribe')
+    args = parser.parse_args()
+
+    credentials = getKey(args.credentials)
+    probabilities = speech_to_text(args.audio, credentials['apikey'], credentials['url'])
+    print(probabilities)


### PR DESCRIPTION
Add a python script to call watson speech to text
and get word probabilities

Not sure about the output format. Currently, I use tuple list for a word and a list for the whole transcription.
For example:
[[('he', 1.0)], [('hoped', 0.99)], [('there', 0.98)], [('would', 0.98)], [('be', 0.98)], [('stew', 0.99)], [('for', 1.0)], [('and', 0.96)], [('carrots', 0.96)], [('and', 1.0)], [('bruised', 1.0)], [('be', 1.0)], [('ladled', 0.98)]]

In the example above, only one candidate for each word. Each tuple contains a word and its probability.

fix: #2 

Signed-off-by: Yihong Wang <yh.wang@ibm.com>